### PR TITLE
ci(recommendations): change to weekly Friday schedule at 5:30 CET

### DIFF
--- a/.github/workflows/send-recommendations.yml
+++ b/.github/workflows/send-recommendations.yml
@@ -2,7 +2,7 @@ name: Send Recommendations
 
 on:
   schedule:
-    - cron: '0 4 * * *' # Daily at 04:00 UTC
+    - cron: '30 3 * * 5' # Weekly on Friday at 05:30 CET (03:30 UTC)
   workflow_dispatch:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Album recommendations are sent automatically via a scheduled GitHub Actions work
 1. Sign up at [resend.com](https://resend.com) and create an API key
 2. Verify a sending domain (or use the test domain for development)
 3. Add the `RESEND_API_KEY` and `FROM_EMAIL` (e.g., `Jazzy <noreply@jazzy.yaennu.ch>`) secrets in **Settings > Secrets and variables > Actions**
-4. The **Send Recommendations** workflow runs daily at 04:00 UTC
+4. The **Send Recommendations** workflow runs weekly on Friday at 05:30 CET (03:30 UTC)
 5. It can also be triggered manually from **Actions > Send Recommendations > Run workflow**
 
 The script checks each user's `newsletter_frequency` preference (daily/weekly/monthly) and sends a random unsent album recommendation to eligible users. When all albums have been sent, the recommendation history resets and starts over from the beginning.


### PR DESCRIPTION
## Summary
- Changed recommendation email schedule from daily at 04:00 UTC to weekly on Friday at 05:30 CET (03:30 UTC)
- Updated GitHub Actions cron schedule in send-recommendations.yml workflow
- Updated README.md documentation to reflect new schedule

🤖 Generated with [Claude Code](https://claude.com/claude-code)