### PR TITLE
fix(imprint): update copyright section to reflect proprietary source-available license

### DIFF
--- a/packages/frontend/src/app/imprint/page.tsx
+++ b/packages/frontend/src/app/imprint/page.tsx
@@ -37,8 +37,9 @@ export default function ImprintPage() {
                 <section className="space-y-3">
                     <h2 className="text-xl font-semibold">Copyright</h2>
                     <p className="text-sm text-gray-700 leading-relaxed">
-                        The source code of Jazzy is licensed under the GNU General Public License v3 (GPLv3) and available on{" "}
-                        <a href="https://github.com/yaennu/jazzy" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline">GitHub</a>.
+                        The source code of Jazzy is proprietary and source-available for evaluation purposes only. It is publicly visible on{" "}
+                        <a href="https://github.com/yaennu/jazzy" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline">GitHub</a>{" "}
+                        but no license is granted to use, copy, modify, or distribute it without a separate written agreement.
                         Album cover art, artist names, and album metadata remain the property of their respective rights holders.
                     </p>
                 </section>


### PR DESCRIPTION
Replaces the outdated GPLv3 reference following the license change in #147.

https://claude.ai/code/session_011hLYC1Zfhu2DzUxWaamv2b